### PR TITLE
TEC-1306: Add bottom padding to landing page to avoid buttons being cut off

### DIFF
--- a/src/design/containers/splash/index.js
+++ b/src/design/containers/splash/index.js
@@ -16,13 +16,14 @@ const SplashOuterEl = styled.div`
   position: relative;
   overflow: auto;
   box-sizing: border-box;
-  padding: 16px 16px 64px 16px;
+  padding: 16px 16px 0 16px;
   @media (max-width: ${theme.screen.mobile}) {
     overflow: auto;
   }
 `
 const SplashInnerEl = styled.div`
   width: 86vw;
+  padding-bottom: 64px;
   max-width: 1227px;
   margin: 0 auto 0;
   display: flex;
@@ -33,6 +34,7 @@ const SplashInnerEl = styled.div`
     height: auto;
     width: 100%;
     padding-top: 130px;
+    padding-bottom: 0;
     flex-direction: column-reverse;
     ${theme.switch({ left: `flex-direction: column;` })}
   }

--- a/src/design/containers/splash/index.js
+++ b/src/design/containers/splash/index.js
@@ -16,7 +16,7 @@ const SplashOuterEl = styled.div`
   position: relative;
   overflow: auto;
   box-sizing: border-box;
-  padding: 16px 16px 0 16px;
+  padding: 16px 16px 64px 16px;
   @media (max-width: ${theme.screen.mobile}) {
     overflow: auto;
   }


### PR DESCRIPTION
[TEC-1306 : Intake form landing doesn't display correctly on short screens](https://linear.app/anika-legal/issue/TEC-1306/intake-form-landing-doesnt-display-correctly-on-short-screens)

Cannot reproduce issue.

"Let's get started" and "Learn more" buttons at the bottom of the landing page have no padding beneath them in certain viewports. This is possibly leading to it being cut off in certain scenarios (e.g. by Chrome downloads bar). This PR adds padding beneath the buttons to hopefully resolve this issue and also provide better space around UI.

Before:
<img width="749" alt="image" src="https://github.com/AnikaLegal/intake/assets/85324964/4b3d32d9-9ed9-4ea3-992f-993fbdfa1b45">

After:
<img width="749" alt="image" src="https://github.com/AnikaLegal/intake/assets/85324964/151604d4-09fb-4006-b4e4-5defbe6eddd3">

