### PR TITLE
TEC-82, TEC-83: Rename final step primary action button and fix to final step stage

### DIFF
--- a/src/questions/index.js
+++ b/src/questions/index.js
@@ -7,6 +7,7 @@ import { events } from 'analytics'
 import { api } from 'api'
 import { storeFormData } from 'utils'
 import type { Field, Data } from 'types'
+import { Icon } from 'design'
 
 import { ABOUT_QUESTIONS } from './about'
 import { ISSUE_QUESTIONS } from './issues'
@@ -21,46 +22,49 @@ export const QUESTIONS: Array<Field> = [
   ...ISSUE_QUESTIONS,
   ...PROPERTY_QUESTIONS,
   ...LANDLORD_QUESTIONS,
-  ...IMPACT_QUESTIONS,
-  {
-    name: 'SUBMIT',
-    required: true,
-    stage: 4,
-    type: FIELD_TYPES.DISPLAY,
-    Prompt: (
-      <span>
-        By submitting this form, you are agreeing to our{' '}
-        <a href={LINKS.PRIVACY_POLICY}>Privacy Policy</a>,{' '}
-        <a href={LINKS.COLLECTIONS_STATEMENT}>Collections Statement</a> and
-        website <a href={LINKS.TERMS_OF_USE}>Terms of Use</a>.
-      </span>
-    ),
-    buttonText: 'Confirm',
-    effect: async (data: Data) => {
-      const finalData = { ...data }
-      // Set all unasked questions to null.
-      for (let q of QUESTIONS) {
-        const isUndef = typeof data[q.name] === 'undefined'
-        const isFailCondition = q.askCondition && !q.askCondition(data)
-        if (isUndef || isFailCondition) {
-          finalData[q.name] = null
-        }
+  ...IMPACT_QUESTIONS
+];
+
+const SUBMIT_QUESTIONS: Field = {
+  name: 'SUBMIT',
+  required: true,
+  stage: Math.max(...QUESTIONS.map(question => question.stage)),
+  type: FIELD_TYPES.DISPLAY,
+  Prompt: (
+    <span>
+      By submitting this form, you are agreeing to our{' '}
+      <a href={LINKS.PRIVACY_POLICY}>Privacy Policy</a>,{' '}
+      <a href={LINKS.COLLECTIONS_STATEMENT}>Collections Statement</a> and
+      website <a href={LINKS.TERMS_OF_USE}>Terms of Use</a>.
+    </span>
+  ),
+  button: { text: 'Confirm', Icon: Icon.Tick },
+  effect: async (data: Data) => {
+    const finalData = { ...data }
+    // Set all unasked questions to null.
+    for (let q of QUESTIONS) {
+      const isUndef = typeof data[q.name] === 'undefined'
+      const isFailCondition = q.askCondition && !q.askCondition(data)
+      if (isUndef || isFailCondition) {
+        finalData[q.name] = null
       }
-      console.log('Submitting data:', finalData)
-      const subId = data['id']
-      let sub
-      if (subId) {
-        // We have already created this submission
-        sub = await api.submission.update(subId, finalData)
-      } else {
-        // This is a new submission
-        sub = await api.submission.create(finalData)
-      }
-      await api.submission.submit(sub.id)
-      // Wipe stored data.
-      storeFormData('')
-      events.onFinishIntake()
-      return ROUTES.SUBMITTED
-    },
+    }
+    console.log('Submitting data:', finalData)
+    const subId = data['id']
+    let sub
+    if (subId) {
+      // We have already created this submission
+      sub = await api.submission.update(subId, finalData)
+    } else {
+      // This is a new submission
+      sub = await api.submission.create(finalData)
+    }
+    await api.submission.submit(sub.id)
+    // Wipe stored data.
+    storeFormData('')
+    events.onFinishIntake()
+    return ROUTES.SUBMITTED
   },
-]
+};
+
+QUESTIONS.push(SUBMIT_QUESTIONS);

--- a/src/questions/index.js
+++ b/src/questions/index.js
@@ -49,7 +49,6 @@ const SUBMIT_QUESTIONS: Field = {
         finalData[q.name] = null
       }
     }
-    console.log('Submitting data:', finalData)
     const subId = data['id']
     let sub
     if (subId) {


### PR DESCRIPTION
[TEC-82 : Change button label at submit from "OK" to "Submit"](https://linear.app/anika-legal/issue/TEC-82/change-button-label-at-submit-from-ok-to-submit)
[TEC-83 : Fix "breadcrumb" indicator position when just prior to submitting](https://linear.app/anika-legal/issue/TEC-83/fix-breadcrumb-indicator-position-when-just-prior-to-submitting)

Renames button at the end of the intake form from "OK" to "Confirm".
Fixes stage of final step in intake form from being hardcoded to 4 to dynamically determining the final stage of all questions.

Before:
<img width="1071" alt="image" src="https://github.com/AnikaLegal/intake/assets/85324964/b8189cad-1927-46ca-9222-d8712856e51a">

After:
<img width="1091" alt="image" src="https://github.com/AnikaLegal/intake/assets/85324964/972a01ae-4fec-46eb-915e-3cb259530660">
